### PR TITLE
Start Emacs in daemon mode

### DIFF
--- a/init.el
+++ b/init.el
@@ -431,5 +431,6 @@ types to search in. Uses `projectile'."
 (require 'package)
 (package-initialize)
 
+(server-start)
 (provide 'init)
 ;;; init.el ends here


### PR DESCRIPTION
Make sure that an emacs server is started at the end of
initialization. This makes it possible to use emacsclient as the
default editor for all operations.